### PR TITLE
Create symlink with constant name to the aion_api jar file

### DIFF
--- a/script/postpack.sh
+++ b/script/postpack.sh
@@ -13,7 +13,7 @@ rm lib/junit-4.12.jar
 VER=$(java -jar ${MOD_NAME} -v)
 echo "Aion Api build ver - $VER"
 mv ${MOD_NAME} "modAionApi-v${VER}-$(date +%Y-%m-%d).jar"
-
+ln -s "modAionApi-v${VER}-$(date +%Y-%m-%d).jar" modAionApi.jar 
 mv ${LIB_NAME} "libAionApi-v${VER}-$(date +%Y-%m-%d).jar"
 tar -czf "libAionApi-v${VER}-$(date +%Y-%m-%d).tar.gz" "libAionApi-v${VER}-$(date +%Y-%m-%d).jar" native lib Java-API-*.doc.zip
 cd ..


### PR DESCRIPTION
Added this symlink so that modGui can refer to the aion_api jar file as a dependency (since the jar file name is dynamic, it was hard to reference from other build.xml files)