### PR TITLE
Fixed MsgExecutor response msg

### DIFF
--- a/src/org/aion/api/impl/MsgExecutor.java
+++ b/src/org/aion/api/impl/MsgExecutor.java
@@ -46,7 +46,6 @@ import org.zeromq.ZMQ.Context;
 import org.zeromq.ZMQ.PollItem;
 import org.zeromq.ZMQ.Socket;
 
-import java.nio.ByteBuffer;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/org/aion/api/impl/MsgExecutor.java
+++ b/src/org/aion/api/impl/MsgExecutor.java
@@ -152,9 +152,8 @@ public class MsgExecutor implements Runnable {
                     }
 
                     if (status == 105) {
-                        msgRsp.setTxResult(ByteArrayWrapper.wrap(ByteBuffer
-                            .wrap(rsp.getData(), rsp.getData()[0] + 1,
-                                rsp.getData().length - (rsp.getData()[0] + 1)).array()));
+                        msgRsp.setTxResult(ByteArrayWrapper.wrap(
+                            Arrays.copyOfRange(rsp.getData(), rsp.getData()[0] + 1, rsp.getData().length)));
                     }
                 } else {
                     // if response message = 68, that is a contract deploy


### PR DESCRIPTION
When status is 105 the MsgExecutor returns the message response but this response is prepended by a byte representing the size of the error code (so that the error code can be skipped over and the response itself can be sent) but currently the jumping doesn't work and the length-byte and everything afterwards gets sent off as the response.

This fix just grabs the response at the correct starting index.