### PR TITLE
Expose functionality needed for Ledger integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 config/
 output/
 out/
-aion.iml
+build/
+pack/
+*.iml
 META-INF
 build/
 pack/

--- a/src/org/aion/api/type/core/tx/AbstractTransaction.java
+++ b/src/org/aion/api/type/core/tx/AbstractTransaction.java
@@ -115,6 +115,10 @@ public abstract class AbstractTransaction implements ITransaction {
 //        }
 //    }
 
+    public void setSignature(final ISignature signature) {
+        this.signature = signature;
+    }
+
     public abstract byte[] getEncoded();
 
     public abstract Address getFrom();

--- a/src/org/aion/api/type/core/tx/AionTransaction.java
+++ b/src/org/aion/api/type/core/tx/AionTransaction.java
@@ -25,11 +25,6 @@
 
 package org.aion.api.type.core.tx;
 
-import static org.aion.base.util.ByteUtil.ZERO_BYTE_ARRAY;
-
-import java.math.BigInteger;
-import java.util.Arrays;
-
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteUtil;
 import org.aion.base.util.TimeInstant;
@@ -40,6 +35,11 @@ import org.aion.crypto.ISignature;
 import org.aion.crypto.SignatureFac;
 import org.aion.rlp.RLP;
 import org.aion.rlp.RLPList;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.aion.base.util.ByteUtil.ZERO_BYTE_ARRAY;
 
 /**
  * 
@@ -178,7 +178,7 @@ public class AionTransaction extends AbstractTransaction {
         return hash;
     }
 
-    private byte[] getRawHash() {
+    public byte[] getRawHash() {
         if (!parsed) {
             rlpParse();
         }
@@ -350,7 +350,7 @@ public class AionTransaction extends AbstractTransaction {
      * For signatures you have to keep also RLP of the transaction without any
      * signature data
      */
-    private byte[] getEncodedRaw() {
+    public byte[] getEncodedRaw() {
 
         if (!parsed) {
             rlpParse();


### PR DESCRIPTION
In order to integrate the `aion_ui` with the Ledger we need to be able to get the hashRaw of an `AionTransaction` in order to send it to the Ledger device that will return a signature for that.
And in the end we will need to insert the retrieved signature into the `AionTransaction` before sending a raw transaction via the API. 

To accomplish the above we need to:
1. Make `AionTransaction.getRawHash()` a public method
2. Add a public method for `setSignature(ISignature)`

