### PR TITLE
add jsr305 dependency so aion_api can build without being a subproject of aion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.7'
     compile 'ch.qos.logback:logback-core:1.2.3'
     compile 'ch.qos.logback:logback-classic:1.2.3'
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
     
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.42'


### PR DESCRIPTION
jsr305 is needed for `@NonNull`.  aion_api can't compile when it is not used as a subproject of aion because it doesn't explicitly depend on it (but works when it is part of aion, because aion has it).

This PR adds the dependency.  

Test:
- `./gradlew clean build` from `aion_api` when it is not a subproject of aion succeeds
- `./gradlew clean build` from `aion_api` when it is a subproject of aion succeeds
- `./gradlew clean build pack` from `aion` when `aion_api` is pointing to this branch succeeds