### PR TITLE
Rename libnzmq because its Gradle project name changes in aion repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
         compile project(':modCrypto')
         compile project(':modLogger')
         compile project(':modRlp')
-        compile project(':3rdParty/libnzmq')
+        compile project(':3rdParty.libnzmq')
     } else {
         compile files("./mod/modAionBase.jar")
         compile files("./mod/modCrypto.jar")


### PR DESCRIPTION
- Needed for https://github.com/aionnetwork/aion/pull/812
- There is a circular depdendency between the two PRs, so they need to both be pushed at the same time