### PR TITLE
Add libnzmq to module-info (make IntelliJ happy)

### DIFF
--- a/src/module-info.java
+++ b/src/module-info.java
@@ -12,6 +12,7 @@ module aion.api.client {
     requires jsr305;
     requires gson;
     requires aion.vm.api;
+    requires libnzmq;
 
     exports org.aion.api;
     exports org.aion.api.type;


### PR DESCRIPTION
aion_api's module-info doesn't have libnzmq.  

This is ok in Gradle build, but IntelliJ gets a compile error.  This is because the Gradle's build logic is slightly different from IntelliJ's build logic.

Related: https://github.com/aionnetwork/aion/pull/815 